### PR TITLE
Add support for parsing WireGuard config from text input

### DIFF
--- a/config.go
+++ b/config.go
@@ -232,6 +232,21 @@ func ParsePeers(cfg *ini.File) ([]PeerConfig, error) {
 	return peers, nil
 }
 
+// parseConfigFromIni is a shared helper function that parses an ini.File into Configuration
+func parseConfigFromIni(cfg *ini.File) (*Configuration, error) {
+	iface, err := ParseInterface(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	peers, err := ParsePeers(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Configuration{Interface: &iface, Peers: peers}, nil
+}
+
 // ParseConfig takes the path of a configuration file and parses it into Configuration
 func ParseConfig(path string) (*Configuration, error) {
 	iniOpt := ini.LoadOptions{
@@ -245,15 +260,21 @@ func ParseConfig(path string) (*Configuration, error) {
 		return nil, err
 	}
 
-	iface, err := ParseInterface(cfg)
+	return parseConfigFromIni(cfg)
+}
+
+// ParseConfigFromText takes configuration text directly and parses it into Configuration
+func ParseConfigFromText(configText string) (*Configuration, error) {
+	iniOpt := ini.LoadOptions{
+		Insensitive:            true,
+		AllowShadows:           true,
+		AllowNonUniqueSections: true,
+	}
+
+	cfg, err := ini.LoadSources(iniOpt, []byte(configText))
 	if err != nil {
 		return nil, err
 	}
 
-	peers, err := ParsePeers(cfg)
-	if err != nil {
-		return nil, err
-	}
-
-	return &Configuration{Interface: &iface, Peers: peers}, nil
+	return parseConfigFromIni(cfg)
 }

--- a/config_test.go
+++ b/config_test.go
@@ -2,19 +2,7 @@ package wiresocks
 
 import (
 	"testing"
-
-	"github.com/go-ini/ini"
 )
-
-func loadIniConfig(config string) (*ini.File, error) {
-	iniOpt := ini.LoadOptions{
-		Insensitive:            true,
-		AllowShadows:           true,
-		AllowNonUniqueSections: true,
-	}
-
-	return ini.LoadSources(iniOpt, []byte(config))
-}
 
 func TestWireguardConfWithoutSubnet(t *testing.T) {
 	const config = `
@@ -28,12 +16,8 @@ PublicKey = dGhpcyBpcyBhIHRlc3QgcHVibGljIGtleS4uLi4uLi4=
 AllowedIPs = 0.0.0.0/0
 Endpoint = 1.2.3.4:51820
 PersistentKeepalive = 25`
-	iniData, err := loadIniConfig(config)
-	if err != nil {
-		t.Fatal(err)
-	}
 
-	_, err = ParseInterface(iniData)
+	_, err := ParseConfigFromText(config)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -51,12 +35,8 @@ PublicKey = onemorekeyonemorekeyonemorekeyonemorekeynow=
 AllowedIPs = 192.168.1.0/24
 Endpoint = 5.6.7.8:51820
 PersistentKeepalive = 15`
-	iniData, err := loadIniConfig(config)
-	if err != nil {
-		t.Fatal(err)
-	}
 
-	_, err = ParseInterface(iniData)
+	_, err := ParseConfigFromText(config)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -73,12 +53,8 @@ DNS = 208.67.222.222,208.67.220.220
 PublicKey = "BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB="
 AllowedIPs = 0.0.0.0/0,::/0
 Endpoint = 9.9.9.9:51820`
-	iniData, err := loadIniConfig(config)
-	if err != nil {
-		t.Fatal(err)
-	}
 
-	_, err = ParseInterface(iniData)
+	_, err := ParseConfigFromText(config)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -7,12 +7,12 @@ toolchain go1.24.6
 require (
 	github.com/amnezia-vpn/amneziawg-go v0.2.13
 	github.com/go-ini/ini v1.67.0
+	github.com/spf13/cobra v1.9.1
 )
 
 require (
 	github.com/google/btree v1.1.3 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
-	github.com/spf13/cobra v1.9.1 // indirect
 	github.com/spf13/pflag v1.0.6 // indirect
 	github.com/tevino/abool v1.2.0 // indirect
 	go.uber.org/atomic v1.11.0 // indirect


### PR DESCRIPTION
### Summary
Extends the configuration parser to accept direct text input in addition to file-based parsing, providing more flexibility for applications that need to parse WireGuard configurations from strings, environment variables, or other text sources.

### Changes
- Added `ParseConfigFromText(configText string)` function for parsing configuration from string input
- Refactored existing parsing logic into shared `parseConfigFromIni()` helper to eliminate code duplication
- Maintained backward compatibility with existing `ParseConfig(path string)` function
- Both parsing methods now use identical validation and processing logic

### Usage
```go
// Existing file-based parsing (unchanged)
config, err := ParseConfig("/path/to/config.conf")

// New text-based parsing
configText := `[Interface]
PrivateKey = ...
Address = 10.0.0.1/24

[Peer]
PublicKey = ...
Endpoint = example.com:51820`

config, err := ParseConfigFromText(configText)
```